### PR TITLE
Usando novamente HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,14 +98,15 @@ ENV/
 # mkdocs documentation
 /site
 
+# database
+sqlalchemy_test
+db/test_db.py
+postgres/
+
 # bot
 token
 .tmp/*.txt
 .tmp*.log
 *.db
-
-
-sqlalchemy_test
 tycot
-db/test_db.py
 TODO

--- a/README.md
+++ b/README.md
@@ -32,28 +32,30 @@ $ python3 bot.py SEU:TOKEN
 
 ### Lista de Comandos do Bot
 - Usuário:
-    - `/info`   mostra informações do grupo e usuário
-    - `/ajuda`  mostra a ajuda
-    - `/regras` mostra as regras do grupo
-    - `/link`   mostra o link do grupo
+    - `/info`   Mostra informações do grupo e usuário.
+    - `/ajuda`  Mostra a ajuda.
+    - `/regras` Mostra as regras do grupo.
+    - `/link`   Mostra o link do grupo.
 - Admin:
-    - `/start`      adiciona o grupo ao banco de dados do tycot, só pode ser usado uma vez
-    - `/defwelcome` define a mensagem de boas-vindas do grupo
-    - `/defmaxwarn` define a quantidade maxima de advertencias que um usúario pode levar
-    - `/defregras`  define as regras do grupo
-    - `/deflink`    define o link do grupo, se o grupo for um supergrupo o link é definido automaticamente
-    - `/ban`        bani o usúario do grupo
-    - `/warn`       adverte o usúario
-    - `/unwarn`     desadverte o usúario
+    - `/start`      Adiciona o grupo ao banco de dados do tycot, só pode ser usado uma vez.
+    - `/defwelcome` Define a mensagem de boas-vindas do grupo.
+    - `/defmaxwarn` Define a quantidade maxima de advertencias que um usúario pode levar.
+    - `/defregras`  Define as regras do grupo.
+    - `/deflink`    Define o link do grupo, se o grupo for um supergrupo o link é definido automaticamente.
+    - `/ban`        Bani o usúario do grupo.
+    - `/warn`       Adverte o usúario.
+    - `/unwarn`     Desadverte o usúario.
 
 
 ### Contribuidores
 [![Danrley](https://s.gravatar.com/avatar/6854dd9f3f8fc5f363ef5d5f9db1da8c?s=80)](https://github.com/dansenpir)  
-[Danrley](https://github.com/dansenpir)  
+[Danrley](https://github.com/dansenpir)
 
 [![Carlos](https://s.gravatar.com/avatar/b29f6fb12e1e61f1d2a46e1ec2834696?s=80)](https://github.com/chcdc)  
-[Carlos](https://github.com/chcdc)  
+[Carlos](https://github.com/chcdc)
 
-[![LaBatata101](https://avatars2.githubusercontent.com/u/20308796?s=80&v=4)](https://github.com/LaBatata101)
+[![LaBatata101](https://avatars2.githubusercontent.com/u/20308796?s=80&v=4)](https://github.com/LaBatata101)  
 [LaBatata101](https://github.com/LaBatata101)
 
+[![Tiago Danin](https://avatars2.githubusercontent.com/u/5731176?s=80&v=4)](https://github.com/TiagoDanin)  
+[Tiago Danin](https://github.com/TiagoDanin)

--- a/admin_cmd.py
+++ b/admin_cmd.py
@@ -28,8 +28,8 @@ class AdminCmd(object):
             self.bot.sendMessage(self.metadata['chat_id'], 'Seu grupo foi cadastrado com sucesso!',
                                  reply_to_message_id=self.metadata['msg_id'])
         else:
-            self.bot.sendMessage(self.metadata['chat_id'], '*Seu grupo já está cadastrado!*',
-                                 parse_mode='Markdown',
+            self.bot.sendMessage(self.metadata['chat_id'], '<b>Seu grupo já está cadastrado!</b>',
+                                 parse_mode='HTML',
                                  reply_to_message_id=self.metadata['msg_id'])
 
     @group.only
@@ -59,11 +59,11 @@ class AdminCmd(object):
         try:
             self.bot.kickChatMember(self.metadata['chat_id'], user_id)
             self.bot.sendMessage(self.metadata['chat_id'],
-                                 f'*{user_first_name}* foi retirado do grupo.',
-                                 parse_mode='Markdown', reply_to_message_id=msg_id)
+                                 f'<b>{user_first_name}</b> foi retirado do grupo.',
+                                 parse_mode='HTML', reply_to_message_id=msg_id)
         except TelegramError:
             self.bot.sendMessage(self.metadata['chat_id'],
-                                 f'*Não posso banir administradores!*', parse_mode='Markdown',
+                                 f'<b>Não posso banir administradores!</b>', parse_mode='HTML',
                                  reply_to_message_id=msg_id)
 
     @group.only
@@ -92,8 +92,8 @@ class AdminCmd(object):
         user_name = user.user_name
         if user.total_warns == group_max_warn:
             self.bot.sendMessage(self.metadata['chat_id'],
-                                 f'*{user_name}* expulso por atingir o limite de advertencias.',
-                                 parse_mode='Markdown',
+                                 f'<b>{user_name}</b> expulso por atingir o limite de advertencias.',
+                                 parse_mode='HTML',
                                  reply_to_message_id=self.metadata['rpl_msg_id'])
             remove_from_db(user)
             self.bot.kickChatMember(self.metadata['chat_id'], self.metadata['rpl_user_id'])
@@ -105,8 +105,8 @@ class AdminCmd(object):
         msg_id = self.metadata['rpl_msg_id']
         if user_id in self.tycot.admins_ids:
             self.bot.sendMessage(self.metadata['chat_id'],
-                                 (f'*{first_name}* é um dos administradores.\n'
-                                 'Não posso advertir administradores.'), parse_mode='Markdown',
+                                 (f'<b>{first_name}</b> é um dos administradores.\n'
+                                 'Não posso advertir administradores.'), parse_mode='HTML',
                                  reply_to_message_id=self.metadata['msg_id'])
         else:
             if not user_exist(self.metadata['chat_id'], user_id):
@@ -116,9 +116,9 @@ class AdminCmd(object):
             group_max_warns = get_max_warns(self.metadata['chat_id'])
             warn_user(self.metadata['chat_id'], user_id)
             self.bot.sendMessage(self.metadata['chat_id'],
-                                 (f'{first_name} *foi advertido'
-                                  f' ({user.total_warns}/{group_max_warns})*.'),
-                                 parse_mode='Markdown',
+                                 (f'{first_name} <b>foi advertido'
+                                  f' ({user.total_warns}/{group_max_warns})</b>.'),
+                                 parse_mode='HTML',
                                  # reply_markup=self.keyboard_warn(user_id),
                                  reply_to_message_id=msg_id)
             self._kick_user(user, group_max_warns)
@@ -136,11 +136,11 @@ class AdminCmd(object):
             user = get_user(user_id)[0]  # get the user from db
             if user.total_warns == 0:
                 self.bot.sendMessage(self.metadata['chat_id'],
-                                     f'*{first_name}* não possui advertencias.',
-                                     parse_mode='Markdown',
+                                     f'<b>{first_name}</b> não possui advertencias.',
+                                     parse_mode='HTML',
                                      reply_to_message_id=msg_id)
             else:
                 unwarn_user(self.metadata['chat_id'], user_id)
-                self.bot.sendMessage(self.metadata['chat_id'], f'*{first_name} foi perdoado.*',
-                                     parse_mode='Markdown',
+                self.bot.sendMessage(self.metadata['chat_id'], f'<b>{first_name} foi perdoado.</b>',
+                                     parse_mode='HTML',
                                      reply_to_message_id=msg_id)

--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,9 @@ def handle(msg):
 
 # TODO: melhorar issu
     text_cmd = msg['text'].split(' ')[0]
-    if text_cmd in user_cmd:
+    if text_cmd == '/start' and tycot.is_private():
+        tycot.usercmd.help()
+    elif text_cmd in user_cmd:
         user_cmd[text_cmd]()
     elif text_cmd in adm_cmd:
         if tycot.is_adm():

--- a/decorators/group.py
+++ b/decorators/group.py
@@ -3,7 +3,7 @@ def only(func):
     def inner(*args, **kwargs):
         if args[0].metadata['chat_type'] == 'private':
             args[0].bot.sendMessage(args[0].metadata['chat_id'],
-                                    '*Este comando só funciona em grupos!*', parse_mode='Markdown',
+                                    '<b>Este comando só funciona em grupos!</b>', parse_mode='HTML',
                                     reply_to_message_id=args[0].metadata['msg_id'])
             return
         func(*args, **kwargs)

--- a/tycot_bot.py
+++ b/tycot_bot.py
@@ -47,7 +47,7 @@ class TycotBot(object):
         welcome = get_welcome_msg(self.metadata['chat_id'])
         if welcome:
             welcome = welcome.replace('$user', user_first_name)
-            self.bot.sendMessage(self.metadata['chat_id'], welcome, parse_mode='Markdown')
+            self.bot.sendMessage(self.metadata['chat_id'], welcome, parse_mode='HTML')
         else:
             self.bot.sendMessage(self.metadata['chat_id'],
                                  f'Seja Bem Vindo(a) ao {chat_name}, {user_first_name}')
@@ -72,7 +72,7 @@ class TycotBot(object):
     def is_adm(self):
         if self.metadata['user_id'] in self.admins_ids:
             return True
-        self.bot.sendMessage(chat_id=self.metadata['chat_id'], parse_mode='Markdown',
-                             text='*Apenas administradores podem usar este comando.*',
+        self.bot.sendMessage(chat_id=self.metadata['chat_id'], parse_mode='HTML',
+                             text='<b>Apenas administradores podem usar este comando.</b>',
                              reply_to_message_id=self.metadata['msg_id'])
         return False

--- a/tycot_bot.py
+++ b/tycot_bot.py
@@ -76,3 +76,9 @@ class TycotBot(object):
                              text='<b>Apenas administradores podem usar este comando.</b>',
                              reply_to_message_id=self.metadata['msg_id'])
         return False
+
+    def is_private(self):
+        if self.metadata['chat_type'] == 'private':
+            return True
+        else:
+            return False

--- a/user_cmd.py
+++ b/user_cmd.py
@@ -16,7 +16,7 @@ class UserCmd(object):
         '''
         Show information about the user or group
         '''
-        output = ('<b>INFO</b>\n
+        output = ('<b>INFO</b>\n'
                   '==================\n')
         chat_id = self.metadata['chat_id']
         if self.metadata['chat_type'] != 'private':
@@ -29,14 +29,14 @@ class UserCmd(object):
 
             max_warn = get_max_warns(self.metadata['chat_id'])
 
-            output += (f'<pre>ID DO GRUPO</pre> : {chat_id}\n'
-                       f'<pre>TOTAL DE ADVERTENCIAS</pre> : {max_warn}\n'
-                       f'<pre>SUAS ADVERTENCIAS</pre> : {user_adv}\n')
+            output += (f'<code>ID DO GRUPO</code> : {chat_id}\n'
+                       f'<code>TOTAL DE ADVERTENCIAS</code> : {max_warn}\n'
+                       f'<code>SUAS ADVERTENCIAS</code> : {user_adv}\n')
 
         nome = self.metadata['username']
         id = self.metadata['user_id']
-        output += (f'<pre>NOME</pre> : {nome}\n'
-                   f'<pre>ID</pre>   : {id}')
+        output += (f'<code>NOME</code> : {nome}\n'
+                   f'<code>ID</code>   : {id}')
 
         self.bot.sendMessage(
             chat_id=chat_id,

--- a/user_cmd.py
+++ b/user_cmd.py
@@ -16,59 +16,56 @@ class UserCmd(object):
         '''
         Show information about the user or group
         '''
+        output = ('<b>INFO</b>\n
+                  '==================\n')
+        chat_id = self.metadata['chat_id']
         if self.metadata['chat_type'] != 'private':
-            msg = ('*INFO*\n'
-                   '==================\n'
-                   '`ID DO GRUPO` : {chat_id}\n'
-                   '`TOTAL DE ADVERTENCIAS` : {max_warn}\n'
-                   '`SUAS ADVERTENCIAS` : {user_adv}\n'
-                   '`NOME` : {nome}\n'
-                   '`ID`   : {id}')
-            # get user warns
+            # Get user warns
             user = get_user(self.metadata['user_id'])
             if user:
                 user_adv = user[0].total_warns
             else:
                 user_adv = 0
 
-            self.bot.sendMessage(chat_id=self.metadata['chat_id'], parse_mode='Markdown',
-                                 text=msg.format(chat_id=self.metadata['chat_id'],
-                                                 max_warn=get_max_warns(self.metadata['chat_id']),
-                                                 user_adv=user_adv,
-                                                 nome=self.metadata['username'],
-                                                 id=self.metadata['user_id']),
-                                 reply_to_message_id=self.metadata['msg_id'])
-        else:
-            msg = ('*ID INFO*\n'
-                   '==================\n'
-                   '`NOME` : {nome}\n'
-                   '`ID`   : {id}')
-            self.bot.sendMessage(chat_id=self.metadata['chat_id'], parse_mode='Markdown',
-                                 text=msg.format(nome=self.metadata['username'],
-                                                 id=self.metadata['user_id']),
-                                 reply_to_message_id=self.metadata['msg_id'])
+            max_warn = get_max_warns(self.metadata['chat_id'])
+
+            output += (f'<pre>ID DO GRUPO</pre> : {chat_id}\n'
+                       f'<pre>TOTAL DE ADVERTENCIAS</pre> : {max_warn}\n'
+                       f'<pre>SUAS ADVERTENCIAS</pre> : {user_adv}\n')
+
+        nome = self.metadata['username']
+        id = self.metadata['user_id']
+        output += (f'<pre>NOME</pre> : {nome}\n'
+                   f'<pre>ID</pre>   : {id}')
+
+        self.bot.sendMessage(
+            chat_id=chat_id,
+            parse_mode='HTML',
+            text=output,
+            reply_to_message_id=self.metadata['msg_id']
+        )
 
     def help(self):
         help_msg = '''
 Olá, sou o Tycot!
-Segue minha lista de comandos:
-    /ajuda -> mostra essa mensagem
-    /info -> informações do grupo
-    /link -> link do grupo
-    /regras -> regras do grupo
-    /verifybook -> verifica o ultimo livro do packtpub
-                          '''
+Segue abaixo minha lista de comandos:
+/ajuda -> Mostra essa mensagem com lista de comandos.
+/info -> Informações do grupo.
+/link -> Link do grupo.
+/regras -> Regras do grupo.
+/verifybook -> Verifica o último livro do PacktPub.
+                   '''
         self.bot.sendMessage(self.metadata['user_id'], help_msg)
 
     @group.only
     def rules(self):
         rules = get_rules(self.metadata['chat_id'])
         if rules:
-            self.bot.sendMessage(self.metadata['chat_id'], rules, parse_mode='Markdown',
+            self.bot.sendMessage(self.metadata['chat_id'], rules, parse_mode='HTML',
                                  reply_to_message_id=self.metadata['msg_id'])
         else:
-            self.bot.sendMessage(self.metadata['chat_id'], '*Sem regras definidas no grupo!*',
-                                 parse_mode='Markdown',
+            self.bot.sendMessage(self.metadata['chat_id'], '<b>Sem regras definidas no grupo!</b>',
+                                 parse_mode='HTML',
                                  reply_to_message_id=self.metadata['msg_id'])
 
     @group.only

--- a/user_cmd.py
+++ b/user_cmd.py
@@ -53,7 +53,6 @@ Segue abaixo minha lista de comandos:
 /info -> Informações do grupo.
 /link -> Link do grupo.
 /regras -> Regras do grupo.
-/verifybook -> Verifica o último livro do PacktPub.
                    '''
         self.bot.sendMessage(self.metadata['user_id'], help_msg)
 


### PR DESCRIPTION
# Resumo
O uso do Markdown trás muitos problemas no parse do Telegram. Recomendável usar HTML.

# Modificações
- Parse_mode de Markdown ~> HTML
- Removido comando do `/verifybook` (Plugin atualmente é inexistentes)
- Melhorando o comando `/info`
- Fix e Update README.md
- Comando `/start` no PV é igual ao `/ajuda` (`/start` é comando padrão executado na primeira interação com o bot no PV)